### PR TITLE
Add minimal ORCID source

### DIFF
--- a/src/quickstatements_client/model.py
+++ b/src/quickstatements_client/model.py
@@ -244,8 +244,15 @@ def lines_to_url(lines: Iterable[Line]) -> str:
     return f"https://quickstatements.toolforge.org/#/v1={quoted_qs}"
 
 
-def lines_to_new_tab(lines: Iterable[Line]):
-    """Open a web browser on the host system."""
+def lines_to_new_tab(lines: Iterable[Line]) -> bool:
+    """Open a web browser on the host system.
+
+    :param lines: QuickStatements lines
+    :returns: If a web browser was successfully invoked (via :func:`webbrowser.open`)
+    """
+    lines = list(lines)
+    if not lines:
+        return False
     return webbrowser.open_new_tab(lines_to_url(lines))
 
 

--- a/src/quickstatements_client/model.py
+++ b/src/quickstatements_client/model.py
@@ -31,7 +31,7 @@ def _safe_field(*, regex: Optional[str] = None, **kwargs) -> Field:
     try:
         rv = Field(regex=regex, **kwargs)
     except TypeError:
-        rv = Field(pattern=regex)
+        rv = Field(pattern=regex, **kwargs)
     return rv
 
 

--- a/src/quickstatements_client/sources/orcid.py
+++ b/src/quickstatements_client/sources/orcid.py
@@ -51,11 +51,13 @@ def get_orcid_qid(orcid: str) -> Optional[str]:
     return get_qid("P496", orcid)
 
 
-def iter_orcid_lines(orcid: str, create: bool = True) -> Iterable[Line]:
+def iter_orcid_lines(orcid: str, create: bool = True, append: bool = False) -> Iterable[Line]:
     """Yield QuickStatements lines about a person from ORCID.
 
     :param orcid: The target ORCID identifier
-    :param create: Should a new QID be created if none can be found?
+    :param create: Should a new QID be created if none can be found? Defaults to true.
+    :param append: Should lines be added to an existing QID? Defaults to false.
+        If set to true, could make duplicate statements on an existing QID.
     :yields: QuickStatements lines
     """
     _raise_on_invalid_orcid(orcid)
@@ -69,6 +71,8 @@ def iter_orcid_lines(orcid: str, create: bool = True) -> Iterable[Line]:
         name = data["name"]
         yield TextLine(subject=orcid_qid, predicate="Len", target=name)
         yield TextLine(subject=orcid_qid, predicate="Den", target=f"Researcher ORCID={orcid}")
+    elif not append:
+        return
 
     pypi_qualifier = TextQualifier(
         predicate="S854",  # reference URL

--- a/src/quickstatements_client/sources/orcid.py
+++ b/src/quickstatements_client/sources/orcid.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+
+"""Create QuickStatements from the ORCID API.
+
+.. seealso:: More detailed functionality is implemented in https://github.com/lubianat/pyorcidator
+"""
+
+import re
+from typing import Iterable, Optional
+
+import requests
+
+from quickstatements_client.model import (
+    CreateLine,
+    DateQualifier,
+    EntityLine,
+    Line,
+    TextLine,
+    TextQualifier,
+)
+from quickstatements_client.sources.utils import get_qid
+
+__all__ = ["get_orcid_data", "get_orcid_qid", "iter_orcid_lines"]
+
+
+ORCID_RE = re.compile(r"^\d{4}-\d{4}-\d{4}-\d{3}(\d|X)$")
+
+
+def _raise_on_invalid_orcid(orcid: str) -> None:
+    if not ORCID_RE.match(orcid):
+        raise ValueError
+
+
+def get_orcid_data(orcid: str):
+    """Get data from the ORCID API."""
+    _raise_on_invalid_orcid(orcid)
+    res = requests.get(
+        f"https://orcid.org/{orcid}", headers={"Accept": "application/json"}, timeout=10
+    ).json()
+    name_dict = res["person"]["name"]
+    name = name_dict["given-names"]["value"] + " " + name_dict["family-name"]["value"]
+    rv = {
+        "name": name,
+    }
+    return rv
+
+
+def get_orcid_qid(orcid: str) -> Optional[str]:
+    """Get the QID for an ORCID."""
+    _raise_on_invalid_orcid(orcid)
+    return get_qid("P496", orcid)
+
+
+def iter_orcid_lines(orcid: str, create: bool = True) -> Iterable[Line]:
+    """Yield QuickStatements lines about a person from ORCID.
+
+    :param orcid: The target ORCID identifier
+    :param create: Should a new QID be created if none can be found?
+    :yields: QuickStatements lines
+    """
+    _raise_on_invalid_orcid(orcid)
+    data = get_orcid_data(orcid)
+    orcid_qid = get_orcid_qid(orcid)
+    if not orcid_qid:
+        if not create:
+            return
+        yield CreateLine()
+        orcid_qid = "LAST"
+        name = data["name"]
+        yield TextLine(subject=orcid_qid, predicate="Len", target=name)
+        yield TextLine(subject=orcid_qid, predicate="Den", target=f"Researcher ORCID={orcid}")
+
+    pypi_qualifier = TextQualifier(
+        predicate="S854",  # reference URL
+        target=f"https://orcid.org/{orcid}",
+    )
+    retrieved_qualifier = DateQualifier.retrieved(namespace="S")
+    qualifiers = [pypi_qualifier, retrieved_qualifier]
+
+    yield EntityLine(
+        subject=orcid_qid,
+        predicate="P31",  # instance of
+        target="Q5",  # human
+        qualifiers=qualifiers,
+    )
+    yield EntityLine(
+        subject=orcid_qid,
+        predicate="P106",  # occupation
+        target="Q1650915",  # researcher
+        qualifiers=qualifiers,
+    )
+    yield TextLine(
+        subject=orcid_qid,
+        predicate="P496",  # ORCID
+        target=orcid,
+        qualifiers=qualifiers,
+    )
+
+
+if __name__ == "__main__":
+    from quickstatements_client.model import lines_to_new_tab
+
+    lines_to_new_tab(iter_orcid_lines("0000-0001-6677-8489"))

--- a/src/quickstatements_client/sources/pypi.py
+++ b/src/quickstatements_client/sources/pypi.py
@@ -18,7 +18,6 @@ from quickstatements_client.model import (
     Line,
     TextLine,
     TextQualifier,
-    lines_to_new_tab,
 )
 from quickstatements_client.sources.utils import query_wikidata, removeprefix
 
@@ -252,5 +251,7 @@ def _dict_get(data: Mapping[str, str], keys: Sequence[str]) -> Optional[str]:
 
 
 if __name__ == "__main__":
+    from quickstatements_client.model import lines_to_new_tab
+
     # print(render_lines(iter_pypi_lines("quickstatements-client"), sep="\t", newline="\n"))
     lines_to_new_tab(iter_pypi_lines("bioregistry"))

--- a/src/quickstatements_client/sources/utils.py
+++ b/src/quickstatements_client/sources/utils.py
@@ -2,7 +2,7 @@
 
 """Utilities for Wikidata."""
 
-from typing import Any, List, Mapping
+from typing import Any, List, Mapping, Optional
 
 import requests
 
@@ -18,20 +18,23 @@ __all__ = [
 WIKIDATA_ENDPOINT = "https://query.wikidata.org/bigdata/namespace/wdq/sparql"
 
 
-def query_wikidata(sparql: str) -> List[Mapping[str, Any]]:
+def query_wikidata(sparql: str, timeout: Optional[float] = None) -> List[Mapping[str, Any]]:
     """Query Wikidata's sparql service.
 
     :param sparql: A SPARQL query string
+    :param timeout: Number of seconds before timeout. Defaults to 10 seconds.
     :return: A list of bindings
     """
     headers = {
         "User-Agent": f"quickstatements_client v{get_version()}",
     }
+    if timeout is None:
+        timeout = 10
     res = requests.get(
         WIKIDATA_ENDPOINT,
         params={"query": sparql, "format": "json"},
         headers=headers,
-        timeout=300,
+        timeout=timeout,
     )
     res.raise_for_status()
     res_json = res.json()
@@ -51,3 +54,12 @@ def removeprefix(s: str, prefix: str) -> str:
 def _clean_value(value: str) -> str:
     value = removeprefix(value, "http://www.wikidata.org/entity/")
     return value
+
+
+def get_qid(prop: str, value: str, timeout: Optional[float] = None) -> Optional[str]:
+    """Get the Wikidata item's QID based on the given property and value."""
+    query = f'SELECT ?item WHERE {{ ?item wdt:{prop} "{value}" . }} LIMIT 1'
+    records = query_wikidata(query, timeout=timeout)
+    if not records:
+        return None
+    return records[0]["item"]

--- a/tests/test_orcid.py
+++ b/tests/test_orcid.py
@@ -1,0 +1,51 @@
+"""Tests for ORCID."""
+import unittest
+
+from quickstatements_client import CreateLine, EntityLine, TextLine
+from quickstatements_client.sources.orcid import iter_orcid_lines
+
+
+class TestORCID(unittest.TestCase):
+    """Tests for ORCID."""
+
+    def test_exists(self):
+        """Test what happens on a page that exists."""
+        orcid = "0000-0003-4423-4370"  # Represents Charlie, who already has a page
+
+        lines = list(iter_orcid_lines(orcid, append=False))
+        self.assertEqual([], lines)
+
+        lines = list(iter_orcid_lines(orcid, append=True))
+        self.assertEqual(3, len(lines))
+        instance_line, occupation_line, orcid_line = lines
+
+        self.assertIsInstance(instance_line, EntityLine)
+        self.assertEqual("P31", instance_line.predicate)
+        self.assertEqual("Q5", instance_line.target)
+        self.assertIsInstance(occupation_line, EntityLine)
+        self.assertEqual("P106", occupation_line.predicate)
+        self.assertEqual("Q1650915", occupation_line.target)
+        self.assertIsInstance(orcid_line, TextLine)
+        self.assertEqual(orcid, orcid_line.target)
+
+    def test_not_exists(self):
+        """Test an ORCID that does not exist."""
+        orcid = "0000-0003-4518-7959"  # person from discipline who probably won't get added
+        lines = list(iter_orcid_lines(orcid))
+        self.assertEqual(6, len(lines))
+        create_line, len_line, den_line, instance_line, occupation_line, orcid_line = lines
+
+        self.assertIsInstance(create_line, CreateLine)
+        self.assertIsInstance(len_line, TextLine)
+        self.assertEqual("Len", len_line.predicate)
+        self.assertEqual("CHEN chen", len_line.target)
+        self.assertIsInstance(den_line, TextLine)
+        self.assertEqual("Den", den_line.predicate)
+        self.assertIsInstance(instance_line, EntityLine)
+        self.assertEqual("P31", instance_line.predicate)
+        self.assertEqual("Q5", instance_line.target)
+        self.assertIsInstance(occupation_line, EntityLine)
+        self.assertEqual("P106", occupation_line.predicate)
+        self.assertEqual("Q1650915", occupation_line.target)
+        self.assertIsInstance(orcid_line, TextLine)
+        self.assertEqual(orcid, orcid_line.target)


### PR DESCRIPTION
This adds a very simple ORCID source that takes care of the name, occupation (researcher) and ORCID ID for a new Wikidata record. More detailed functionality for ORCID is implemented in https://github.com/lubianat/pyorcidator